### PR TITLE
Decoding response data v2

### DIFF
--- a/pyrsp/rsp.py
+++ b/pyrsp/rsp.py
@@ -22,7 +22,7 @@ if os.path.exists(activate_this):
     execfile(activate_this, dict(__file__=activate_this))
 
 import serial
-from pyrsp.utils import hexdump, pack, unpack, unhex, switch_endian, split_by_n
+from pyrsp.utils import hexdump, pack, unpack, unhex, switch_endian, split_by_n, decode_data
 from pyrsp.elf import ELF
 from binascii import hexlify
 
@@ -248,9 +248,9 @@ class RSP(object):
         """ loads and caches values of the registers on the device """
         self.send('g')
         if self.arch['endian']:
-            self.regs=dict(zip(self.registers,(switch_endian(reg) for reg in split_by_n(self.readpkt(),self.arch['bitsize']>>2))))
+            self.regs=dict(zip(self.registers,(switch_endian(reg) for reg in split_by_n(decode_data(self.readpkt()),self.arch['bitsize']>>2))))
         else:
-            self.regs=dict(zip(self.registers,split_by_n(self.readpkt(),self.arch['bitsize']>>2)))
+            self.regs=dict(zip(self.registers,split_by_n(decode_data(self.readpkt()),self.arch['bitsize']>>2)))
 
     def dump_regs(self):
         """ refreshes and dumps registers via stdout """

--- a/pyrsp/utils.py
+++ b/pyrsp/utils.py
@@ -31,6 +31,24 @@ def unpack(pkt):
     pkt = pkt[1:-3]
     return pkt
 
+def decode_data(data):
+    """ decodes data from received packet, decoding algorithm is described
+here: https://sourceware.org/gdb/onlinedocs/gdb/Overview.html
+    """
+    if data.find('*') == -1:
+        return data
+    else:
+        decoded_data = ""
+        j = -1
+        for i, ch in enumerate(data):
+            if ch == '*' and data[i - 1] != '*':
+                n = ord(data[i + 1]) - 29
+                decoded_data = decoded_data + (data[i - 1] * n)
+                j = i + 1
+            elif i != j:
+                decoded_data = decoded_data + ch
+        return decoded_data
+
 def unhex(data):
     """ takes a hex encoded string and returns the binary representation """
     return ''.join(chr(int(x,16)) for x in split_by_n(data,2))


### PR DESCRIPTION
Response data can be run-length encoded to save space (encoding algorithm is described here: https://sourceware.org/gdb/onlinedocs/gdb/Overview.html). For this reason, it is necessary to be able to decode such data.
This patch implements it.
I tested this by connecting to a gdbserver running on the PC. 

Signed-off-by: Koltunov Dmitry <koltunov@ispras.ru>