### PR TITLE
Startup without shell

### DIFF
--- a/pyrsp/rsp.py
+++ b/pyrsp/rsp.py
@@ -88,7 +88,8 @@ class STlink2(object):
         self.port.close()
 
 class RSP(object):
-    def __init__(self, port, elffile=None, verbose=False, noack=False):
+    def __init__(self, port, elffile=None, verbose=False, noack=False,
+                 noshell=False):
         """ read the elf file if given by elffile, connects to the
             debugging device specified by port, and initializes itself.
         """
@@ -136,6 +137,14 @@ class RSP(object):
                 self.cont_all = self.vContc_all
             if "s" in actions:
                 self.step = self.vConts
+
+        if noshell and "QStartupWithShell+" in self.feats:
+            # extended mode is required
+            self.fetchOK("!")
+            self.fetchOK("QStartupWithShell:0")
+            self.noshell = True
+        else:
+            self.noshell = False
 
         # attach
         self.connect()

--- a/test/tests.py
+++ b/test/tests.py
@@ -54,7 +54,7 @@ class TestUser(TestRSP):
         if rsp_port is None:
             raise RuntimeError("Cannot find free port!")
         self._port = port = str(rsp_port)
-        self._gdb = gdb = Popen(["gdbserver", "--no-startup-with-shell", "localhost:" + port, self.EXE])
+        self._gdb = gdb = Popen(["gdbserver", "localhost:" + port, self.EXE])
 
         # Wait for gdb to start listening.
         if not wait_for_tcp_port(rsp_port) or gdb.returncode is not None:
@@ -63,7 +63,8 @@ class TestUser(TestRSP):
         self._target = rsp(self._port,
             elffile = self.EXE,
             verbose = True,
-            noack = self.noack
+            noack = self.noack,
+            noshell = True
         )
 
     def tearDown(self):


### PR DESCRIPTION
There is a problem with "--no-startup-with-shell" option to `gdbserver`.
My `gdbserver` does not know it. As a result, user mode tests failed.

There is another way to start without shell.
It's using special RSP command "QStartupWithShell" with `0` value.
Unfortunately, my `gdbserver` does not know it too.
But, there is safe protocol defined way to handle this issue (without `gdbserver`
launch failure).

I implemented it, but I'm not sure the implementation is correct.
It's likely that your `gdbserver` that understands  "--no-startup-with-shell" CLI
option, also supports "QStartupWithShell" RSP command.
According to the protocol [spec][1], `gdbserver` must declare "QStartupWithShell" in
its response to "qSupported".
Could you please test it.
Failing tests is quite annoying.

[1]: https://sourceware.org/gdb/onlinedocs/gdb/General-Query-Packets.html#index-QStartupWithShell-packet