### PR TITLE
Fixup `KeyError` in `RSP.run`

### DIFF
--- a/pyrsp/rsp.py
+++ b/pyrsp/rsp.py
@@ -622,6 +622,18 @@ class RSP(object):
         if self.dump(2048) != b'\x00' * 2048:
             raise ValueError('cannot erase work area')
 
+    def get_arg(self, n):
+        "Returns hex encoded value of argument #n of current function call"
+        try:
+            # call_regs attribute is set by either user or predefined
+            # targets (below)
+            reg_name = self.call_regs[n - 1]
+        except IndexError:
+            # TODO: implement getting from stack
+            raise NotImplementedError(
+                "Getting of argument #%d is not implemented" % n)
+        return self.regs[reg_name]
+
 from .cortexhwregs import *
 class CortexM3(RSP):
     def __init__(self, *args,**kwargs):
@@ -711,6 +723,8 @@ class CortexM3(RSP):
                 print(unhex(pkt[1:-1]))
             pkt=self.readpkt()
 
+    call_regs = ("r0", "r1", "r2", "r3")
+
 class AMD64(RSP):
     def __init__(self, *args,**kwargs):
         self.arch = {'regs': ["rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rbp", "rsp",
@@ -726,6 +740,9 @@ class AMD64(RSP):
         self.pc_reg = "rip"
         super(AMD64,self).__init__(*args, **kwargs)
 
+    # System V AMD64 ABI calling convention is assumed
+    call_regs = ("rdi", "rsi", "rdx", "rcx", "r8", "r9") + tuple("xmm%d" for d in range(8))
+
 class i386(RSP):
     # TODO gdb sends qSupported:multiprocess+;xmlRegisters=i386;qRelocInsn+
     def __init__(self, *args,**kwargs):
@@ -739,6 +756,9 @@ class i386(RSP):
                     'bitsize': 32}
         self.pc_reg = "eip"
         super(i386,self).__init__(*args, **kwargs)
+
+    # fastcall calling convention is assumed
+    call_regs = ("ecx", "edx")
 
 archmap={'amd64': AMD64, "x86_64": AMD64, "i386": i386, "cortexm3": CortexM3}
 

--- a/pyrsp/rsp.py
+++ b/pyrsp/rsp.py
@@ -556,7 +556,7 @@ class RSP(object):
         addr = self.regs[self.pc_reg]
         self.del_br(addr, quiet=True)
         kind, sig, _ = stop_reply(self.step())
-        if kind == b'T' and sig in (5, 0x0b):
+        if kind in (b'T', b'S') and sig in (5, 0x0b):
             self.set_br_a(addr, back["cb"], quiet=True, sym=back["sym"])
         else:
             print('strange signal while stepi over br, abort')

--- a/pyrsp/rsp.py
+++ b/pyrsp/rsp.py
@@ -407,7 +407,14 @@ class RSP(object):
         while kind in (b'T', b'S') and sig == 5:
             # Update current thread for a breakpoint handler.
             event = stop_event(data)
-            self.thread = event[b"thread"]
+            # If server does not specify a thread explicitly then assume that
+            # current thread has not been changed.
+            # XXX: There is no statement found in the protocol specification
+            # about that aspect. Moreover, it's server implementation
+            # dependent. So, a user must manage threads carefully with respect
+            # to the implementation.
+            if b"thread" in event:
+                self.thread = event[b"thread"]
             self.handle_br()
             if self.exit:
                 return

--- a/pyrsp/utils.py
+++ b/pyrsp/utils.py
@@ -188,7 +188,8 @@ def wait_for_tcp_port(port, timeout = 5.0):
     while time() - t0 < timeout:
         conns = net_connections(kind = "tcp4")
         for conn in conns:
-            if conn.laddr.port == port:
+            # Note that laddr became a named tuple only since 5.3.0
+            if conn.laddr[1] == port:
                 return True
     return False
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,3 +3,4 @@ test-calls.exe
 test-threads.exe
 test-callback.exe
 test-memory.exe
+test-fastcall.exe

--- a/test/test-fastcall.c
+++ b/test/test-fastcall.c
@@ -1,0 +1,11 @@
+#include "test.h"
+
+ARG_ON_REG void foo(int val)
+{
+    /* nop */
+}
+
+void main(void)
+{
+    foo(0xDEADBEEF);
+}

--- a/test/tests.py
+++ b/test/tests.py
@@ -307,6 +307,16 @@ class TestUserI386FastCall(QemuUserI386, TestRSP):
         target.run(setpc = False)
         self.assertTrue(self._br, "breakpoint skipped")
 
+    def test_fastcall(self):
+        target = self._target
+        def br():
+            self.assertEqual(int(target.get_arg(1), 16), 0xDEADBEEF,
+                "foo argument has unexpected value")
+            target.step_over_br()
+
+        target.set_br("foo", br)
+        target.run(setpc = False)
+
 
 class TestARM(ExampleBuilder, TestRSP):
     arch = "cortexm3"


### PR DESCRIPTION
Qemu GDB stub in _user_ mode does not include thread ID in stop reply packet causing
`RSP.run` to fall on `KeyError`.