### PR TITLE
Fix hanging #2

### DIFF
--- a/pyrsp/rsp.py
+++ b/pyrsp/rsp.py
@@ -92,7 +92,7 @@ class STlink2(object):
         if not buf:
             try:
                 buf = self.port.recv(4096)
-            except:
+            except socket.timeout:
                 pass
             else:
                 if buf == b'':


### PR DESCRIPTION
`socket.recv` can raise exceptions of different types.
Only timeout exception can be ignored because other types indicate a failure
of the socket. Ignoring them results in hanging of `RSP`'s methods.